### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.box = "precise64"
+    config.vm.box = "ubuntu/precise64"
 
     config.vm.network :private_network, ip: "192.168.10.53"
     config.vm.network :forwarded_port, guest: 80, host: 8053
@@ -22,5 +22,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # the path on the host to the actual folder. The second argument is
     # the path on the guest to mount the folder. And the optional third
     # argument is a set of non-required options.
+    ###
+    # IMPORTANT
+    ###
+    # Before you boot up this machine set the first argument "D:/abid/php/" to you html pulbic path
     config.vm.synced_folder "D:/abid/php/", "/var/www/html"
 end


### PR DESCRIPTION
changed box name from precise64 to ubuntu/precise64 to work on newer versions of vagrant also added a comment with instructions to set file sharing of public folder.